### PR TITLE
fix desktop safari cannot exit full screen by clicking the fullscreen…

### DIFF
--- a/src/pannellum/js/pannellum.js
+++ b/src/pannellum/js/pannellum.js
@@ -2099,7 +2099,8 @@ window.pannellum = (function(window, document, undefined) {
  * @private
  */
     function onFullScreenChange() {
-      if (document.fullscreen || document.mozFullScreen || document.webkitIsFullScreen || document.msFullscreenElement) {
+      let isFullScreen = (window.innerWidth == screen.width && window.innerHeight == screen.height);
+      if (document.fullscreen || document.mozFullScreen || document.webkitIsFullScreen || document.msFullscreenElement || isFullScreen) {
         controls.fullscreen.classList.add('pnlm-fullscreen-toggle-button-active');
         fullscreenActive = true;
       } else {


### PR DESCRIPTION
Desktop Safari is possible to enter full screen. But the full screen button does not change to exit full screen button.

Here are the values after entering full screen

- document.fullscreen -> undefined
- document.mozFullScreen -> undefined
- document.webkitIsFullScreen -> false
- document.msFullscreenElement -> undefined

Here is a trick to compare window size and screen size to determine if it is currently in full screen.