### PR TITLE
added onRender config for callback. Added and propagated disable KB nav

### DIFF
--- a/src/elements/Pannellum.js
+++ b/src/elements/Pannellum.js
@@ -48,6 +48,7 @@ class Pannellum extends PureComponent {
     keyboardZoom: propTypes.bool,
     mouseZoom: propTypes.bool,
     draggable: propTypes.bool,
+    disableKeyboardCtrl : propTypes.bool,
     showFullscreenCtrl: propTypes.bool,
     showControls: propTypes.bool,
     onLoad: propTypes.func,
@@ -64,7 +65,8 @@ class Pannellum extends PureComponent {
     tooltipArg: propTypes.object,
     handleClick: propTypes.func,
     handleClickArg: propTypes.object,
-    cssClass: propTypes.string
+    cssClass: propTypes.string,
+    onRender: propTypes.func
   };
 
   static defaultProps = {
@@ -94,6 +96,7 @@ class Pannellum extends PureComponent {
     keyboardZoom: true,
     mouseZoom: true,
     draggable: true,
+    disableKeyboardCtrl: false,
     showFullscreenCtrl: true,
     showControls: true,
     onLoad: () => {},
@@ -105,7 +108,8 @@ class Pannellum extends PureComponent {
     onMouseup: () => {},
     onTouchstart: () => {},
     onTouchend: () => {},
-    hotspotDebug: false
+    hotspotDebug: false,
+    onRender: null
   };
 
   renderImage = state => {
@@ -181,10 +185,12 @@ class Pannellum extends PureComponent {
       keyboardZoom: this.props.keyboardZoom,
       mouseZoom: this.props.mouseZoom,
       draggable: this.props.draggable,
+      disableKeyboardCtrl: this.props.disableKeyboardCtrl,
       showFullscreenCtrl: this.props.showFullscreenCtrl,
       showControls: this.props.showControls,
       hotSpotDebug: this.props.hotspotDebug,
-      hotSpots: hotspotArray
+      hotSpots: hotspotArray,
+      onRender: this.props.onRender
     };
 
     Object.keys(jsonConfig).forEach(

--- a/src/pannellum/js/pannellum.js
+++ b/src/pannellum/js/pannellum.js
@@ -1471,6 +1471,10 @@ window.pannellum = (function(window, document, undefined) {
           compass.style.transform = 'rotate(' + (-config.yaw - config.northOffset) + 'deg)';
           compass.style.webkitTransform = 'rotate(' + (-config.yaw - config.northOffset) + 'deg)';
         }
+        
+        if (config.onRender) {
+          config.onRender();
+        }
       }
     }
 


### PR DESCRIPTION
There is a need to know when a render was completed (for example, to update other components that reflect yaw/pitch/fov). To facilitate this, I added an `onRender` callback config prop. If the user passes it, it will be invoked at the end of each render.

Also, the `disableKeyboardCtrl` was not supported and it is required. Added it to the props