### PR TITLE
Scene fix

### DIFF
--- a/demo/src/components/ImageDemo.js
+++ b/demo/src/components/ImageDemo.js
@@ -71,6 +71,8 @@ export default class ImageDemo extends Component {
         <div className="pannellum_div">
           <Pannellum
             ref={this.ref}
+            id="sceneId"
+            sceneId="firstScene"
             width="800px"
             height="400px"
             image={this.state.mediaPhoto}

--- a/src/elements/Pannellum.js
+++ b/src/elements/Pannellum.js
@@ -210,10 +210,19 @@ class Pannellum extends PureComponent {
     if (state === "update") {
       this.panorama.destroy();
     } 
-    this.panorama = pannellum.viewer(
-      this.props.id ? this.props.id : this.state.id,
-      jsonConfig
-    );
+
+    const panorama = jsonConfig.panorama;
+    this.panorama = pannellum.viewer(this.props.id, {
+      default: {
+        firstScene: this.props.id ? this.props.id : this.state.id
+      },
+      scenes: {
+        [this.props.id ? this.props.id : this.state.id]: {
+          ...jsonConfig,
+          panorama
+        }
+      }
+    });
 
     this.panorama.on("load", this.props.onLoad);
     this.panorama.on("scenechange", this.props.onScenechange);

--- a/src/pannellum/js/pannellum.js
+++ b/src/pannellum/js/pannellum.js
@@ -2740,7 +2740,10 @@ window.pannellum = (function(window, document, undefined) {
  * @returns {string} ID of current scene
  */
     this.getScene = function() {
-      return config.scene;
+      return {
+        currentSceneId: config.scene,
+        sceneConfig: config.scenes[config.scene]
+      };
     };
 
     /**


### PR DESCRIPTION
Changing the configuration of pannellum.viewer() so that the scene is initialised. Therefore all functions that use and rely on scene can be used.