### PR TITLE
fix issue with non existing css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "umd"
   ],
   "scripts": {
-    "build": "nwb build-react-component",
+    "build": "nwb build-react-component --copy-files",
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react",


### PR DESCRIPTION
nwb didn't copy the css files that are used in the `.js` files, so now it will be copying everything (i dont think there is an option to just copy the css files).

or there any better ideas to fix that issue?
<img width="1040" alt="Bildschirmfoto 2019-04-15 um 04 17 54" src="https://user-images.githubusercontent.com/31381383/56103909-7ad20380-5f35-11e9-8d47-170d55acca84.png">

ps. or dont forget to publish the css via npm next time too 😉 
