### PR TITLE
add support for rendering array of hotspots

### DIFF
--- a/src/elements/Pannellum.js
+++ b/src/elements/Pannellum.js
@@ -121,7 +121,7 @@ class Pannellum extends PureComponent {
   renderImage = state => {
     const { children } = this.props;
     // make the array of sub components, even if its one, it become array of one
-    let hotspots = [...children];
+    let hotspots = children.flatMap(child => child);
     let hotspotArray = [];
     if (Array.isArray(hotspots)) {
       hotspots.map(hotspot => {


### PR DESCRIPTION
I need to render an array of dynamic hotspots in a project where I use the library:
```
<Pannellum ...>
   <Pannellum.Hotspot ... text="static hotspot" />
   {hotspots.map(hotspot => <Pannellum.Hotspot {...hotspot} />}
</Pannellum>
```
The result has been an error, because current implementation does not take an array as a child of `Pannellum` component in account.

So I flatmapped `children` to be a 1D array of hotspots.