### PR TITLE
react peer version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "video.js": "^7.1.0"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": "^16 || ^17 || ^18"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
The lib is working with react 17 and 18. So let's update the peer dependency